### PR TITLE
update battle complete page to handle multiple mints and tiers

### DIFF
--- a/pages/battleComplete/[txHash].tsx
+++ b/pages/battleComplete/[txHash].tsx
@@ -2,8 +2,31 @@ import { Heading, Spinner, Text } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import NFTCard from "../../src/components/NFTCard";
 import { useBattleTransaction } from "../../src/hooks/useBattle";
+import { InventoryItem } from "../../src/hooks/useGameItems";
 import useIsClientSide from "../../src/hooks/useIsClientSide";
 import Layout from "../../src/layouts/Layout";
+
+const CollectedItems: React.FC<{ items: InventoryItem[] }> = ({ items }) => {
+  if (items.length === 1) {
+    return (
+      <>
+        <Text>
+          That means you&apos;ve collected a nice {items[0].metadata.name}.
+        </Text>
+        <NFTCard item={items[0]} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Text>You&apos;ve collected items!</Text>
+      {items.map((item) => {
+        return <NFTCard item={item} key={`battle-completed-${item.id}`} />;
+      })}
+    </>
+  );
+};
 
 const BattleComplete: React.FC = () => {
   const router = useRouter();
@@ -31,15 +54,7 @@ const BattleComplete: React.FC = () => {
           {data.winningItem.metadata.name} beats {data.losingItem.metadata.name}
         </Text>
       )}
-      {data.playerIsWinner && (
-        <>
-          <Text>
-            That means you&apos;ve collected a nice{" "}
-            {data.losingItem.metadata.name}
-          </Text>
-          <NFTCard item={data.losingItem} />
-        </>
-      )}
+      {data.playerIsWinner && <CollectedItems items={data.mintedTokens} />}
     </Layout>
   );
 };

--- a/pages/battleComplete/[txHash].tsx
+++ b/pages/battleComplete/[txHash].tsx
@@ -1,5 +1,6 @@
 import { Heading, Spinner, Text } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import AppLink from "../../src/components/AppLink";
 import NFTCard from "../../src/components/NFTCard";
 import { useBattleTransaction } from "../../src/hooks/useBattle";
 import { InventoryItem } from "../../src/hooks/useGameItems";
@@ -46,8 +47,10 @@ const BattleComplete: React.FC = () => {
   return (
     <Layout>
       {data.playerIsWinner && <Heading>You win!</Heading>}
+      {data.tierUnlocked && <Heading>Tier Unlocked!</Heading>}
       {data.draw && <Heading>Draw! Battle again one day.</Heading>}
       {!data.draw && !data.playerIsWinner && <Heading>You lose.</Heading>}
+      <AppLink href="/inventory">&lt; Back to inventory</AppLink>
       {!data.draw && (
         // TODO: here is where we would substitute "beats" with the verbs from the chart.
         <Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,7 +40,7 @@ export default function Home() {
         </NextLink>
       )}
       <Box>
-        <Video animationUrl="/promoVid.mp4" autoPlay controls></Video>
+        <Video animationUrl="/promoVid.mp4" autoPlay controls muted></Video>
       </Box>
       <Text>A classic game, reimagined on the zero-gas SKALE network </Text>
       <Text>Find someone to play against, choose an item, scan a QR code.</Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,7 +40,7 @@ export default function Home() {
         </NextLink>
       )}
       <Box>
-        <Video animationUrl="/promoVid.mp4" autoPlay controls muted></Video>
+        <Video animationUrl="/promoVid.mp4" autoPlay controls muted playsInline></Video>
       </Box>
       <Text>A classic game, reimagined on the zero-gas SKALE network </Text>
       <Text>Find someone to play against, choose an item, scan a QR code.</Text>

--- a/src/components/NFTCard.tsx
+++ b/src/components/NFTCard.tsx
@@ -15,7 +15,7 @@ const NFTCard: React.FC<{ item: InventoryItem, onChoose?:(tokenId:number) => any
     >
       <Box h="70%" backgroundColor="#000">
         {typeFromUrl(animationUrl) ? (
-          <Video animationUrl={animationUrl} controls={false} autoPlay loop muted />
+          <Video animationUrl={animationUrl} controls={false} autoPlay loop muted playsInline />
         ) : (
           <Image
             src={ipfsToWeb(image)}

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -21,6 +21,7 @@ interface VideoProps extends BoxProps {
   autoPlay?: boolean
   loop?: boolean
   muted?: boolean
+  playsInline?: boolean
 }
 
 const Video: React.FC<VideoProps> = (props) => {

--- a/src/hooks/useGameItems.ts
+++ b/src/hooks/useGameItems.ts
@@ -95,7 +95,7 @@ export const useAllItems = () => {
           animationUrl: item.animationUrl,
           description: item.description,
         },
-      }
+      } as InventoryItem
     }))
   })
 }

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -36,8 +36,8 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           </NextLink>
         </LinkBox>
         <Spacer display={['none', 'none', 'block', 'block']} />
-        { isClient && canOnboard && <AppLink pt="2" href="/onboard">Onboard</AppLink> }
-        <AppLink pt="2" href="/about">About</AppLink>
+        { isClient && canOnboard && <AppLink pt="1.5" href="/onboard">Onboard</AppLink> }
+        <AppLink pt="1.5" href="/about">About</AppLink>
         <Box ml="5">
           <ConnectButton showBalance={false} />
         </Box>


### PR DESCRIPTION
On the battle complete page, look for token mints & tier unlocks and show those to the user.

Sorry there's also a couple of extras in here:

* mute video since it's autoplay
* clean up a useEffects
* back button on complete